### PR TITLE
Added main files to include in bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,10 @@
   "authors": [
     "Ryan Funduk <ryan.funduk@gmail.com>"
   ],
+  "main": [
+    "./dist/jquery-tourbus.css",
+    "./dist/jquery-tourbus.js"
+  ],
   "dependencies": {
     "jquery": ">= 1.8"
   },


### PR DESCRIPTION
When you use https://github.com/stephenplusplus/grunt-wiredep you have the power to include automaticaly the files from packages, for this feature works fine you need add in bower file the main section.
